### PR TITLE
fix: add the missing process before exit function

### DIFF
--- a/bin/pm-runtests.js
+++ b/bin/pm-runtests.js
@@ -12,7 +12,7 @@ let dirs = [], browsers = [], grep = null, server = false
 for (let i = 2, arg; (arg = process.argv[i]) != null; i++) {
   if (arg == "--chrome") browsers.push("chrome")
   else if (arg == "--firefox") browsers.push("firefox")
-  else if (arg == "--help") exit(0)
+  else if (arg == "--help") process.exit(0)
   else if (arg == "--grep") grep = process.argv[++i]
   else if (arg == "--server") server = true
   else if (arg[0] == "-") help()


### PR DESCRIPTION
Hi, I happened to run the `pm-runtests --help` locally in prosemirror repo. And it happened to be missing the process before the exit function call. So a PR may be the fix for it.
![2024-04-03 at 01 02](https://github.com/ProseMirror/buildhelper/assets/3437641/80aa7e12-260f-4bd4-9a25-959d0be1f760)
