### PR TITLE
Support type checking in pm-buildhelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ following:
 
  - Run the TypeScript compiler, catching the output in memory.
 
+ - Fails the build on TypeScript errors with the `--type-check` flag.
+
  - Run rollup and rollup-plugin-dts on the result to emit the CommonJS
    and ES modules, as well as a bundled `.d.ts` file, to `dist/`.
 

--- a/bin/pm-buildhelper.js
+++ b/bin/pm-buildhelper.js
@@ -3,15 +3,20 @@
 const {build} = require("@marijn/buildtool")
 const {resolve} = require("path")
 const {transform} = require("@babel/core")
+const {parseArgs} = require("node:util")
 
-let args = process.argv.slice(2)
+const {values, positionals} = parseArgs({
+  options: {"type-check": {type: "boolean", default: false}},
+  allowPositionals: true
+})
 
-if (args.length != 1) {
-  console.log("Usage: pm-buildhelper src/mainfile.ts")
+if (positionals.length != 1) {
+  console.log("Usage: pm-buildhelper [--type-check] src/mainfile.ts")
   process.exit(1)
 }
 
-build(resolve(args[0]), {
+build(resolve(positionals[0]), {
+  typeCheck: values["type-check"],
   expandLink: anchor => "https://prosemirror.net/docs/ref/#" + anchor,
   expandRootLink: "https://prosemirror.net/",
   cjsOutputPlugin: () => ({

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "pm-runtests": "bin/pm-runtests.js"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=18.3.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/prosemirror/buildhelper.git"
@@ -19,7 +22,7 @@
   "dependencies": {
     "@babel/core": "^7.23.5",
     "@babel/preset-env": "^7.23.5",
-    "@marijn/buildtool": "^1.1.0",
+    "@marijn/buildtool": "^1.2.0",
     "@marijn/testtool": "^0.1.0"
   }
 }


### PR DESCRIPTION
This makes it possible to fail a build if the project has any type errors:

    $ pm-buildhelper --type-check src/schema.ts
    Error: Exit code 1
     Type checking failed:
     src/schema.ts(224,13): error TS2339: Property 'attrs' does not exist on type...

Useful for CI.

Builds on marijnh/buildtool#4.